### PR TITLE
太さ指定スライダーから0が出力されないよう最小値を追加

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -21,7 +21,7 @@
     <div id="pen">
         <input id="color" type="color" value="#FFFFFF">
         <div style="padding: 0 10px;"></div>
-        <input type="range" class="form-range" id="bolder" value="3">
+        <input type="range" class="form-range" id="bolder" value="3" min="0">
         <div style="padding: 0 10px;"></div>
         <input type="checkbox" id="anonym">
         <div style="padding: 0 10px;"></div>


### PR DESCRIPTION
drawing.js内で線の幅指定として使用されているcontext.lineWidthは0より大きい数値でないと無視されるそうです.....
([参考](https://developer.mozilla.org/ja/docs/Web/API/CanvasRenderingContext2D/lineWidth))

ってことで画面上に配置されているスライダーに最小値を追加しました。